### PR TITLE
fix(getContainer): container can be null

### DIFF
--- a/src/getContainer.ts
+++ b/src/getContainer.ts
@@ -1,4 +1,7 @@
-export default (container: Element | (() => Element), defaultContainer?: Element): Element => {
+export default (
+  container: Element | null | (() => Element | null),
+  defaultContainer?: Element
+): Element => {
   container = typeof container === 'function' ? container() : container;
   return container || defaultContainer;
 };

--- a/test/querySpec.js
+++ b/test/querySpec.js
@@ -97,4 +97,30 @@ describe('Query', () => {
       expect(lib.isFocusable(createElement('div', { tabIndex: -1 }))).to.equal(true);
     });
   });
+
+  describe('getContainer', () => {
+    it('Should return the container if present', () => {
+      const container = {};
+
+      expect(lib.getContainer(container)).to.equal(container);
+    });
+
+    it('Should return the return value of container when container is a function', () => {
+      const container = {};
+
+      expect(lib.getContainer(() => container)).to.equal(container);
+    });
+
+    it('Should return defaultContainer if container is null', () => {
+      const defaultContainer = {};
+
+      expect(lib.getContainer(null, defaultContainer)).to.equal(defaultContainer);
+    });
+
+    it('Should return defaultContainer if container returns null', () => {
+      const defaultContainer = {};
+
+      expect(lib.getContainer(() => null, defaultContainer)).to.equal(defaultContainer);
+    });
+  });
 });


### PR DESCRIPTION
The implementation indicates that it's expected if `container` has a falsy value.