### PR TITLE
fix/addStyle-args-type

### DIFF
--- a/src/addStyle.ts
+++ b/src/addStyle.ts
@@ -5,7 +5,7 @@ export interface CSSProperty {
   [key: string]: string | number;
 }
 
-export default (node: Element, property: string | CSSProperty, value?: string | number): void => {
+export default (node: Element, property: string | Partial<CSSProperty>, value?: string | number): void => {
   let css = '';
   let props = property;
 


### PR DESCRIPTION
When the second input parameter of the addStyle function is passed into an empty object, TS will report an error

```javascript
const scrollStyles = momentum
        ? {
            'transition-duration': `${TRANSITION_DURATION}ms`,
            'transition-timing-function': BEZIER || ''
          }
        : {};

addStyle(handleRef.current, scrollStyles);
```