### PR TITLE
Normalize delta values on platforms where event.deltaX is 0 even as event.shiftKey is true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4001,14 +4001,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001274",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
-      "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
+      "version": "1.0.30001410",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001410.tgz",
+      "integrity": "sha512-QoblBnuE+rG0lc3Ur9ltP5q47lbguipa/ncNMyyGuqPk44FxbScWAeEO+k5fSQ8WekdAK4mWqNs1rADDAiN5xQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -23336,9 +23342,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001274",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
-      "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
+      "version": "1.0.30001410",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001410.tgz",
+      "integrity": "sha512-QoblBnuE+rG0lc3Ur9ltP5q47lbguipa/ncNMyyGuqPk44FxbScWAeEO+k5fSQ8WekdAK4mWqNs1rADDAiN5xQ==",
       "dev": true
     },
     "cardinal": {

--- a/src/WheelHandler.ts
+++ b/src/WheelHandler.ts
@@ -2,6 +2,15 @@ import emptyFunction from './utils/emptyFunction';
 import normalizeWheel from './utils/normalizeWheel';
 import requestAnimationFramePolyfill from './requestAnimationFramePolyfill';
 
+const swapWheelAxis = normalizedEvent => {
+  return {
+    spinX: normalizedEvent.spinY,
+    spinY: normalizedEvent.spinX,
+    pixelX: normalizedEvent.pixelY,
+    pixelY: normalizedEvent.pixelX
+  };
+};
+
 class WheelHandler {
   animationFrameID = null;
   deltaX = 0;
@@ -40,7 +49,13 @@ class WheelHandler {
   }
 
   onWheel(event) {
-    const normalizedEvent = normalizeWheel(event);
+    let normalizedEvent = normalizeWheel(event);
+
+    // on some platforms (e.g. Win10), browsers do not automatically swap deltas for horizontal scroll
+    if (navigator.platform !== 'MacIntel' && event.shiftKey) {
+      normalizedEvent = swapWheelAxis(normalizedEvent);
+    }
+
     const deltaX = this.deltaX + normalizedEvent.pixelX;
     const deltaY = this.deltaY + normalizedEvent.pixelY;
     const handleScrollX = this.handleScrollX(deltaX, deltaY);

--- a/test/wheelSpec.js
+++ b/test/wheelSpec.js
@@ -1,0 +1,141 @@
+import { WheelHandler } from '../src';
+
+describe('WheelHandler', () => {
+  let mockEvent;
+  let originalNavigator = global.navigator;
+
+  beforeEach(() => {
+    mockEvent = {
+      preventDefault: () => {},
+      deltaX: 10,
+      deltaY: 0
+    };
+
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        platform: 'MacIntel'
+      }
+    });
+  });
+
+  after(() => {
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator
+    });
+  });
+
+  it('Should return deltaX and deltaY', done => {
+    const wheelHandler = new WheelHandler(
+      (dX, dY) => {
+        expect(dX).to.equal(10);
+        expect(dY).to.equal(0);
+        done();
+      },
+      true,
+      true
+    );
+    wheelHandler.onWheel(mockEvent);
+  });
+
+  it('Should normalize deltas correctly when delta unit is lines', done => {
+    const wheelHandler = new WheelHandler(
+      (dX, dY) => {
+        expect(dX).to.equal(8000);
+        expect(dY).to.equal(800);
+        done();
+      },
+      true,
+      true
+    );
+    wheelHandler.onWheel({
+      ...mockEvent,
+      deltaMode: 2,
+      deltaX: 10,
+      deltaY: 1
+    });
+  });
+
+  it('Should normalize deltas when delta unit is pages', done => {
+    const wheelHandler = new WheelHandler(
+      (dX, dY) => {
+        expect(dX).to.equal(400);
+        expect(dY).to.equal(40);
+        done();
+      },
+      true,
+      true
+    );
+    wheelHandler.onWheel({
+      ...mockEvent,
+      deltaMode: 1,
+      deltaX: 10,
+      deltaY: 1
+    });
+  });
+
+  it('Should take horizontal scrolling with shiftKey + wheel into account on non-MacIntel platforms', done => {
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        platform: 'Win64'
+      }
+    });
+
+    const wheelHandler = new WheelHandler(
+      (dX, dY) => {
+        expect(dX).to.equal(10);
+        expect(dY).to.equal(0);
+        done();
+      },
+      true,
+      true
+    );
+    wheelHandler.onWheel({
+      ...mockEvent,
+      shiftKey: true,
+      deltaX: 0,
+      deltaY: 10
+    });
+  });
+
+  it('Should not treat as horizontal scrolling when event.shiftKey == true if platform is MacIntel', done => {
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        platform: 'MacIntel'
+      }
+    });
+
+    const wheelHandler = new WheelHandler(
+      (dX, dY) => {
+        expect(dX).to.equal(0);
+        expect(dY).to.equal(10);
+        done();
+      },
+      true,
+      true
+    );
+    wheelHandler.onWheel({
+      ...mockEvent,
+      shiftKey: true,
+      deltaX: 0,
+      deltaY: 10
+    });
+  });
+
+  it('Should treat as horizontal scrolling when side scrolling on FF', done => {
+    const wheelHandler = new WheelHandler(
+      (dX, dY) => {
+        expect(dX).to.equal(500);
+        expect(dY).to.equal(0);
+        done();
+      },
+      true,
+      true
+    );
+    wheelHandler.onWheel({
+      detail: 50,
+      axis: 1,
+      HORIZONTAL_AXIS: 1,
+      preventDefault: () => {}
+    });
+  });
+});


### PR DESCRIPTION
Hi,

The current rsuite-table version has an issue where horizontal scroll with mousewheel + shitKey does not work as expected.

The issue can be reproduced & observed by trying to horizontally scroll tables with the mousewheel (wheel + shift key). The common behavior is to scroll horizontally when the shift key is pressed. For rsuite-table this works on some platforms (notably Mac) but not others (Win). 

There's a repro case for rsuite-table (using dom-lib) here:
https://codesandbox.io/s/runtime-star-utr4bh?file=/src/App.js

And a stand-alone repro case for dom-lib showcasing the issue at:
https://codesandbox.io/s/practical-mestorf-6qpp44?file=/src/App.js

Please also ref. the screen recordings below in order to see difference in normalized delta values on Mac vs Windows. Note how the value for `deltaX` stays `0` on Windows, incl. when `shiftKey === true` -- this happens across different browsers (tested onChrome, Edge, Firefox):

[dom-lib deltas on mac](https://drive.google.com/file/d/1i4y4MFAjLKq4UacaLPW1uwW5GZWO8OUI/view?usp=sharing)
[dom-lib deltas on windows](https://drive.google.com/file/d/161obh_3DzJ6NHZbhuexdesGKXWdY83v5/view?usp=sharing)

Since dom-lib appears to be normalizing the deltas I'm proposing doing so here instead of in rsuite-table.
I do realize there's more risk involved in doing it here, though, and would be happy to submit a PR for rsuite-table where the values from dom-lib are used if you don't want to pull the change in here.

Thanks,
Trond