### PR TITLE
fix: remove timeout from global scope

### DIFF
--- a/src/requestAnimationFramePolyfill.ts
+++ b/src/requestAnimationFramePolyfill.ts
@@ -1,4 +1,3 @@
-import emptyFunction from './utils/emptyFunction';
 import getGlobal from './utils/getGlobal';
 
 const g = getGlobal();
@@ -17,8 +16,5 @@ function _setTimeout(callback: (t: number) => void) {
  * @deprecated Use `requestAnimationFrame` instead.
  */
 const requestAnimationFramePolyfill = g.requestAnimationFrame || _setTimeout;
-
-// Works around a rare bug in Safari 6 where the first request is never invoked.
-requestAnimationFramePolyfill(emptyFunction);
 
 export default requestAnimationFramePolyfill;


### PR DESCRIPTION
This PR fixes #83 by removing a timeout that was executed in the global scope, which prevented deployment to Cloudflare Pages. 

The line was introduced to workaround an issue with Safari 6, but since that version is very old now (current Safari is at 17.5), it should be safe to remove. 